### PR TITLE
add django cors headers

### DIFF
--- a/brainbox_api/brainbox_api/settings.py
+++ b/brainbox_api/brainbox_api/settings.py
@@ -44,9 +44,11 @@ INSTALLED_APPS = [
     'api',
     'openai',
     'dotenv',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -128,3 +130,11 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+]
+
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^http:\/\/127\.0\.0\.1:\d{4}"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ certifi==2023.5.7
 charset-normalizer==3.1.0
 decouple==0.0.7
 Django==4.2.1
+django-cors-headers==4.0.0
 djangorestframework==3.14.0
 frozenlist==1.3.3
 idna==3.4


### PR DESCRIPTION
install django-cors-headers
add "http://localhost:3000" and "http://127.0.0.1:d{4}" as permitted origins